### PR TITLE
docs: add contributor note on where tests live

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,16 @@ Changes to the [`harness/`](harness) itself should preserve the core contract: *
 
 ## Checks
 
+### Where tests live
+
+The harness's own tests live in [`harness/tests/`](harness/tests), including the Hypothesis property tests in [`test_properties.py`](harness/tests/test_properties.py).
+
+The full suite runs as part of `harness gate` (at 100% coverage). To run only the harness tests while iterating:
+
+```sh
+uv run pytest harness/tests
+```
+
 Fast check while working [`harness/gate.py line 164`](harness/gate.py#L164)
 
 ```sh


### PR DESCRIPTION
## Summary
Adds a short contributor-facing note to the Checks section of CONTRIBUTING.md,
pointing to where the harness tests live (`harness/tests/`, including the
Hypothesis property tests) and how to run just that suite while iterating.

## Why
The Checks section documents `harness preflight` and `harness gate`, but nothing
tells a new contributor where the tests actually are or how to run only them.

## Checks run
- `uv run pytest harness/tests` — 196 passed
- `uv run harness gate` — lint, pylint, complexipy, security and pytest all passed
  (the pyright phase failed locally only, due to a missing `libatomic1` in my WSL2 environment)

## Notes
Docs-only, no test implementation, per the acceptance criteria.

Closes #20