### PR TITLE
docs: add Claude quickstart section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ harness run codex 2 20
 harness run agy 3 10
 harness run copilot 2 20
 ```
+### Running with claude 
+
+To run LoopGate with Claude :
+
+```sh
+harness run claude 2 20
+```
+Note: The worker must be installed and authenticated separately.
 
 <details>
   <summary>


### PR DESCRIPTION
## Summary of Changes
- Added a new `Running with Claude` subsection directly under the `Commands` section in `README.md`.
- Included the required harness command: `harness run claude 2 20`.
- Added a note indicating that the worker must be installed and authenticated separately.

## Type of Change
- [x] Documentation update (non-breaking change)