### PR TITLE
docs: troubleshoot missing/unauthenticated worker CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ complex_comprehension  # no needlessly dense list/set/dict comprehensions, prefe
 
 ### FAQ </summary>
 
+- **`harness run <agent>` exits immediately / can't find the worker?**
+
+LoopGate does not install or log in agent CLIs. Install and authenticate the worker you selected (`claude`, `codex`, `copilot`, or `agy`), confirm it is on your `PATH` (e.g. `which codex`), then retry. If `which` finds the binary but the run still fails, finish that tool's login/auth flow and retry `harness run`.
+
 - **What is the difference between a gate and a sandbox?**
 
 A **gate** is a workflow checkpoint that evaluates code and decides whether it is allowed to land in your commits. A **sandbox** is an isolated OS-level environment designed to prevent code from modifying your underlying machine. LoopGate uses gates to control your git history, but it does _not_ provide a secure OS sandbox.


### PR DESCRIPTION
## Summary
- Add a FAQ entry for missing/unauthenticated worker CLIs when `harness run` fails early
- Docs-only; no new tests per CONTRIBUTING
- Sanity-checked against `harness run` behavior (name check only; PATH/auth are external)
## Test plan
- [ ] Read FAQ in README for accuracy
- [ ] Confirm Claude one-liner is unchanged