### PR TITLE
feat: pass extra flags through to agent in harness run

### DIFF
--- a/harness/cli.py
+++ b/harness/cli.py
@@ -286,7 +286,6 @@ def run(
     num_iterations: Annotated[int, Argument()] = 2,
     max_minutes: Annotated[int, Argument()] = 20,
     verbose: Annotated[bool, Argument()] = True,
-    *,
     model: Annotated[str | None, Option(help="Override the agent's model")] = None,
 ) -> None:
     """ralph.sh runs once for one agent.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -19,7 +19,7 @@ from rich import print as rprint
 from rich.json import JSON
 from rich.table import Table
 from tomlkit import TOMLDocument, document, dumps, parse, table
-from typer import Argument, Exit, Option, Typer, colors, confirm, echo, prompt, secho, style
+from typer import Argument, Context, Exit, Option, Typer, colors, confirm, echo, prompt, secho, style
 
 from harness.config import ASSETS, CATEGORIES, CLAUDE_RULES, CODEX_RULES, PHASES, get_tools
 from harness.gate import console, gates, run_git
@@ -259,19 +259,23 @@ def check_for_timeout_and_prompt() -> str | None:
 
 
 @app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
     help="Run one harnessed ralph loop with <agent>, e.g. `harness run claude 3 20`.\n\n"
-    f"Agents in pyproject.toml (from tool.harness.agents): {', '.join(gates().agents)}"
+    f"Agents in pyproject.toml (from tool.harness.agents): {', '.join(gates().agents)}",
 )
 def run(
+    ctx: Context,
     agent: str,
     num_iterations: Annotated[int, Argument()] = 2,
     max_minutes: Annotated[int, Argument()] = 20,
     verbose: Annotated[bool, Argument()] = True,
+    *,
     model: Annotated[str | None, Option(help="Override the agent's model")] = None,
 ) -> None:
     """ralph.sh runs once for one agent.
 
     Args:
+        ctx: Typer Context holding unparsed extra arguments.
         agent: Agent key to run.
         num_iterations: Number of ralph loop iterations.
         max_minutes: Wall-clock budget per run in minutes.
@@ -297,8 +301,11 @@ def run(
     )
     agent_argv = [tok.replace("{log_path}", str(log)) for tok in gates().agents[agent]]
     if model:
-        agent_argv[agent_argv.index("--model") + 1] = model
-    command = [*launcher, str(num_iterations), str(max_minutes), *agent_argv]
+        if "--model" in agent_argv:
+            agent_argv[agent_argv.index("--model") + 1] = model
+        else:
+            agent_argv.extend(("--model", model))
+    command = [*launcher, str(num_iterations), str(max_minutes), *agent_argv, *ctx.args]
     echo(f"harness: {' '.join(command)} -> {log}", err=True)
     raise Exit(code=run_worker(command, log, verbose))
 

--- a/harness/tests/test_cli.py
+++ b/harness/tests/test_cli.py
@@ -1562,3 +1562,41 @@ def test_claude_preset_runs_two_real_loop_iterations(monkeypatch: pytest.MonkeyP
     assert [event["type"] for event in events] == ["ralph", "result", "ralph", "result", "ralph"]
     assert [event.get("iteration") for event in events] == [1, None, 2, None, None]
     assert events[-1]["completed"] == 2
+
+
+def test_run_passes_extra_args_to_agent_and_handles_missing_model_in_preset(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path
+) -> None:
+    """Extra flags passed after run arguments reach the agent command, both with and without '--',
+    extra flags can be absent, and overriding --model on a preset without --model appends it.
+    """
+    monkeypatch.chdir(git_repo)
+    monkeypatch.setattr(cli, "IS_WINDOWS", False)
+    monkeypatch.setattr(cli, "check_for_timeout_and_prompt", Mock(return_value="timeout"))
+    freeze_run_day(monkeypatch)
+    (git_repo / "docs").mkdir(exist_ok=True)
+    (git_repo / "docs" / "PROMPT.md").write_text("prompt\n", encoding="utf-8")
+    launched: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", fake_agent(launched))
+
+    # 1. Extra flags without '--'
+    res1 = runner.invoke(cli.app, ["run", "claude", "1", "2", "False", "--effort", "high", "--max-tokens", "4000"])
+    assert res1.exit_code == 0
+    assert launched[0][3:] == [*list(gates().agents["claude"]), "--effort", "high", "--max-tokens", "4000"]
+
+    # 2. Extra flags with '--'
+    res2 = runner.invoke(cli.app, ["run", "claude", "1", "2", "False", "--", "--effort", "high"])
+    assert res2.exit_code == 0
+    assert launched[1][3:] == [*list(gates().agents["claude"]), "--effort", "high"]
+
+    # 3. Extra flags absent
+    res3 = runner.invoke(cli.app, ["run", "claude", "1", "2", "False"])
+    assert res3.exit_code == 0
+    assert launched[2][3:] == list(gates().agents["claude"])
+
+    # 4. Preset without '--model' gets --model appended when model option is passed
+    res4 = runner.invoke(
+        cli.app, ["run", "copilot", "1", "2", "False", "--model", "custom-model", "--", "--extra-flag"]
+    )
+    assert res4.exit_code == 0
+    assert launched[3][3:] == [*list(gates().agents["copilot"]), "--model", "custom-model", "--extra-flag"]


### PR DESCRIPTION
## Summary of changes

Pass unparsed CLI arguments through to the agent command via typer Context.
Enable allow_extra_args and ignore_unknown_options in run command settings.
Safely handle model override when a preset does not contain a model flag.
Add unit tests in harness/tests/test_cli.py covering extra args present, extra args absent, separator form, and model fallback.

## Why this is needed

Closes #48. Allows running agents with custom flags directly from harness run without needing to edit pyproject.toml first.

## Checks run

uv run pytest harness/tests passed (192 passed, 100 percent coverage on harness/cli.py)
uv run harness preflight passed
uv run harness gate passed (248 passed, full project gate passed)
uv run ruff check harness/tests/test_cli.py passed

## Follow up

Keeping positional parameters as documented in option a of issue 48 to avoid breaking existing workflows.
